### PR TITLE
fix: run TypeScript CLI entry files in ESM projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ bootstrap();
 "wz-command": "wz-command"
 ```
 
+The entry file is resolved from `CLI_PATH` (default `./src/cli.ts`), relative to the directory you run the command from. When the entry is a TypeScript file, install `ts-node` (or `tsx`) in your application: it is registered as an ESM loader for projects with `"type": "module"`, and through `ts-node/register` plus `tsconfig-paths` for CommonJS projects.
+
 ## Usage 🚀
 
 Here’s how you can use them. For each type of component, you can use one of the two available command formats: with `npm run` or directly with `wz-command`

--- a/lib/bin/cli
+++ b/lib/bin/cli
@@ -1,13 +1,23 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
-import { createRequire } from 'node:module';
+import { createRequire, register } from 'node:module';
 import { pathToFileURL } from 'node:url';
 
-// The consumer's entry file may be TypeScript / CommonJS, so we still need a CJS
-// require to be able to register `ts-node` and load it. `createRequire` is the
-// ESM-safe way to do that.
-const require = createRequire(import.meta.url);
+// Everything we load on behalf of the consumer (`ts-node`, `tsx`, the entry file
+// itself) lives in the consumer's project, so resolution must be anchored there
+// instead of at this package's location.
+const appRoot = process.cwd();
+const appEntry = path.join(appRoot, 'package.json');
+const appEntryUrl = pathToFileURL(appEntry).href;
+const require = createRequire(appEntry);
+
+// TypeScript loaders usable through `module.register()` under ESM, in preference order.
+const TS_ESM_LOADERS = [
+    { name: 'ts-node', specifier: 'ts-node/esm' },
+    { name: 'tsx', specifier: 'tsx/esm' },
+    { name: '@swc-node/register', specifier: '@swc-node/register/esm' }
+];
 
 function checkModuleExists(name) {
     try {
@@ -17,25 +27,60 @@ function checkModuleExists(name) {
     }
 }
 
+function isEsmProject() {
+    try {
+        return JSON.parse(fs.readFileSync(appEntry, 'utf8')).type === 'module';
+    } catch {
+        return false;
+    }
+}
+
+function registerTsEsmLoader() {
+    for (const loader of TS_ESM_LOADERS) {
+        if (!checkModuleExists(`${loader.name}/package.json`)) {
+            continue;
+        }
+        register(loader.specifier, appEntryUrl);
+        return loader.name;
+    }
+    return false;
+}
+
 async function bootstrap() {
     const CLI_PATH = process.env.CLI_PATH || './src/cli.ts';
-    const cli = path.resolve(process.cwd(), CLI_PATH);
+    const cli = path.resolve(appRoot, CLI_PATH);
 
     const exists = fs.existsSync(cli);
     if (!exists) {
         console.error(`Not found file: ${cli}`);
         return;
     }
+
     if (path.extname(cli) === '.ts') {
-        if (checkModuleExists('tsconfig-paths')) {
-            require('tsconfig-paths').register();
+        if (isEsmProject()) {
+            // `require()` cannot load ESM, and `tsconfig-paths/register` only patches the
+            // CJS resolver, so an ESM project needs a loader hook plus a dynamic import.
+            if (!registerTsEsmLoader()) {
+                console.error(
+                    `Cannot run ${cli}: install ts-node (or tsx) to execute a TypeScript entry file in an ESM project.`
+                );
+                process.exitCode = 1;
+                return;
+            }
+        } else {
+            // CommonJS project: the `ts-node` / `tsconfig-paths` hooks patch the CJS
+            // resolver only, so the entry has to be loaded with `require`.
+            if (checkModuleExists('tsconfig-paths')) {
+                require('tsconfig-paths').register();
+            }
+            if (checkModuleExists('ts-node')) {
+                require('ts-node').register();
+            }
+            require(cli);
+            return;
         }
-        if (checkModuleExists('ts-node')) {
-            require('ts-node').register();
-        }
-        require(cli);
-        return;
     }
+
     await import(pathToFileURL(cli).href);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hodfords/nestjs-command",
-    "version": "12.1.0",
+    "version": "12.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@hodfords/nestjs-command",
-            "version": "12.1.0",
+            "version": "12.1.1",
             "license": "ISC",
             "dependencies": {
                 "es-toolkit": "1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hodfords/nestjs-command",
-    "version": "12.1.0",
+    "version": "12.1.1",
     "description": "A utility for running CLI commands in NestJS apps",
     "type": "module",
     "main": "./index.js",


### PR DESCRIPTION
## Problem

`bin/cli` always loaded a `.ts` entry file through `ts-node` + `require()`. In an application with `"type": "module"` that throws `ERR_REQUIRE_ESM`, so `wz-command` is unusable there. The existing `await import(pathToFileURL(cli).href)` branch only ran for non-`.ts` entries.

Module resolution was also anchored to this package through `createRequire(import.meta.url)`, so `ts-node` and `tsconfig-paths` were resolved inside the library rather than in the consumer application. `tsconfig-paths.register()` is a no-op under ESM anyway, since it only patches the CommonJS resolver.

## Changes

- Anchor all resolution to the application working directory.
- ESM projects: register a TypeScript ESM loader (`ts-node/esm`, `tsx/esm` or `@swc-node/register/esm`) with `module.register()`, then load the entry with a dynamic import. `tsconfig-paths` is not registered there.
- CommonJS projects: keep `tsconfig-paths` + `ts-node/register` + `require(cli)` — a dynamic `import()` would bypass the CJS hooks.
- Fail with an actionable message (and a non-zero exit code) when no TypeScript loader is installed.
- Document the entry-file requirements in the README.
- Bump to 12.1.1.

## Verification

Smoke-tested four scenarios, all behaving as expected:

| Project | Entry | Result |
| --- | --- | --- |
| `"type": "module"` | `src/cli.ts` | loads (previously `ERR_REQUIRE_ESM`) |
| CommonJS | `src/cli.ts` | loads |
| `"type": "module"` | `src/cli.js` | loads |
| `"type": "module"`, no loader installed | `src/cli.ts` | clear error, exit 1 |

`npm test` (3/3) and `npm run lint` pass.