### PR TITLE
fix: declare framework packages as peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hodfords/nestjs-command",
-    "version": "12.1.1",
+    "version": "12.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@hodfords/nestjs-command",
-            "version": "12.1.1",
+            "version": "12.2.0",
             "license": "ISC",
             "dependencies": {
                 "es-toolkit": "1.51.0",
@@ -49,7 +49,8 @@
                 "@nestjs/common": ">=12.0.0",
                 "@nestjs/core": ">=12.0.0",
                 "@nestjs/schedule": "*",
-                "commander": "*"
+                "commander": "*",
+                "typeorm": ">=1.0.0"
             }
         },
         "node_modules/@borewit/text-codec": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hodfords/nestjs-command",
-    "version": "12.1.1",
+    "version": "12.2.0",
     "description": "A utility for running CLI commands in NestJS apps",
     "type": "module",
     "main": "./index.js",
@@ -75,7 +75,8 @@
         "@nestjs/common": ">=12.0.0",
         "@nestjs/core": ">=12.0.0",
         "@nestjs/schedule": "*",
-        "commander": "*"
+        "commander": "*",
+        "typeorm": ">=1.0.0"
     },
     "optionalDependencies": {
         "typeorm": "*"


### PR DESCRIPTION
## Problem

The published code of this package imports these modules at runtime, but they
were only listed in `devDependencies` — which consumers never install. The
package therefore shipped with **no version contract** for them.

With npm's flat `node_modules` the imports happen to land on the application's
own copy. With pnpm's isolated layout they do not: the package's own directory
in `.pnpm/<pkg>/node_modules/` only contains its *declared* dependencies, so
Node walks up and resolves through `.pnpm/node_modules/` (pnpm's hoist target)
instead. Depending on what got hoisted there, the package binds to a *different*
physical copy than the application — or fails to resolve at all.

Two instances of `@nestjs/common` in one process means two distinct
`HttpException` classes, so `instanceof` fails, `@Catch(HttpException)` never
matches, and DI tokens/metadata do not line up. `peerDependencies` is exactly
the mechanism that tells pnpm to link the package to the host application's copy.

## Changes

Declared as `peerDependencies`:

| package | range | |
|---|---|---|
| `typeorm` | `>=1.0.0` | required — runtime import |

Version: **@hodfords/nestjs-command@12.2.0** (minor — the requirement already existed at runtime, this only makes it explicit).

## Verification

- `npm run build` and `npm test` pass.
- Packed the built artifact and installed it into a pnpm project alongside the
  application's own Nest packages: every declared peer now resolves to the
  **same physical instance** as the application, and `instanceof` across the
  package boundary works.

## Note for consumers

Applications that were relying on these packages being resolved implicitly may
now see an unmet-peer warning on install. That warning is the bug becoming
visible — adding the package to the application's own `package.json` is the fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
