### PR TITLE
fix(bin): detect TypeScript loaders whose exports map hides package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ bootstrap();
 "wz-command": "wz-command"
 ```
 
-The entry file is resolved from `CLI_PATH` (default `./src/cli.ts`), relative to the directory you run the command from. When the entry is a TypeScript file, install `ts-node` (or `tsx`) in your application: it is registered as an ESM loader for projects with `"type": "module"`, and through `ts-node/register` plus `tsconfig-paths` for CommonJS projects.
+The entry file is resolved from `CLI_PATH` (default `./src/cli.ts`), relative to the directory you run the command from. When the entry is a TypeScript file, install `ts-node`, `tsx` or `@swc-node/register` in your application: it is registered as an ESM loader for projects with `"type": "module"`, and through `ts-node/register` plus `tsconfig-paths` for CommonJS projects.
 
 ## Usage 🚀
 

--- a/lib/bin/cli
+++ b/lib/bin/cli
@@ -27,6 +27,14 @@ function checkModuleExists(name) {
     }
 }
 
+// Whether `name` is installed anywhere on the consumer's resolution path. Unlike
+// `require.resolve('<name>/package.json')`, this does not depend on the package's
+// `exports` map exposing `./package.json` — `@swc-node/register` does not.
+function checkPackageInstalled(name) {
+    const searchPaths = require.resolve.paths(name) ?? [];
+    return searchPaths.some((dir) => fs.existsSync(path.join(dir, name, 'package.json')));
+}
+
 function isEsmProject() {
     try {
         return JSON.parse(fs.readFileSync(appEntry, 'utf8')).type === 'module';
@@ -37,7 +45,7 @@ function isEsmProject() {
 
 function registerTsEsmLoader() {
     for (const loader of TS_ESM_LOADERS) {
-        if (!checkModuleExists(`${loader.name}/package.json`)) {
+        if (!checkPackageInstalled(loader.name)) {
             continue;
         }
         register(loader.specifier, appEntryUrl);
@@ -62,7 +70,7 @@ async function bootstrap() {
             // CJS resolver, so an ESM project needs a loader hook plus a dynamic import.
             if (!registerTsEsmLoader()) {
                 console.error(
-                    `Cannot run ${cli}: install ts-node (or tsx) to execute a TypeScript entry file in an ESM project.`
+                    `Cannot run ${cli}: install ts-node, tsx or @swc-node/register to execute a TypeScript entry file in an ESM project.`
                 );
                 process.exitCode = 1;
                 return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hodfords/nestjs-command",
-    "version": "12.3.0",
+    "version": "12.3.1",
     "packageManager": "pnpm@12.0.0",
     "description": "A utility for running CLI commands in NestJS apps",
     "type": "module",

--- a/tests/bin-cli.spec.ts
+++ b/tests/bin-cli.spec.ts
@@ -1,0 +1,66 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const CLI = resolve(import.meta.dirname, '../lib/bin/cli');
+
+function writeJson(file: string, value: unknown): void {
+    writeFileSync(file, JSON.stringify(value, null, 4));
+}
+
+/**
+ * Lays out a minimal ESM app whose only TypeScript loader is a stand-in for
+ * `@swc-node/register`: its `exports` map exposes `./esm` but not
+ * `./package.json`, exactly like the published package.
+ */
+function scaffoldEsmApp(root: string): void {
+    mkdirSync(join(root, 'src'), { recursive: true });
+    writeJson(join(root, 'package.json'), { name: 'app', type: 'module' });
+    writeFileSync(join(root, 'src/cli.ts'), "console.log('cli ran');\n");
+
+    const loaderRoot = join(root, 'node_modules/@swc-node/register');
+    mkdirSync(join(loaderRoot, 'esm'), { recursive: true });
+    writeJson(join(loaderRoot, 'package.json'), {
+        name: '@swc-node/register',
+        exports: { '.': { node: './index.js' }, './esm': { import: './esm/esm.mjs' } }
+    });
+    writeFileSync(join(loaderRoot, 'index.js'), '');
+    writeFileSync(join(loaderRoot, 'esm/esm.mjs'), "process.stdout.write('loader registered\\n');\n");
+}
+
+describe('bin/cli', () => {
+    const roots: string[] = [];
+
+    afterEach(() => {
+        for (const root of roots.splice(0)) {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('registers a loader whose exports map hides package.json', () => {
+        const root = mkdtempSync(join(tmpdir(), 'nestjs-command-'));
+        roots.push(root);
+        scaffoldEsmApp(root);
+
+        const result = spawnSync(process.execPath, [CLI], { cwd: root, encoding: 'utf8' });
+
+        expect(result.stderr).not.toContain('install ts-node');
+        expect(result.stdout).toContain('loader registered');
+        expect(result.stdout).toContain('cli ran');
+        expect(result.status).toBe(0);
+    });
+
+    it('still fails clearly when no TypeScript loader is installed', () => {
+        const root = mkdtempSync(join(tmpdir(), 'nestjs-command-'));
+        roots.push(root);
+        scaffoldEsmApp(root);
+        rmSync(join(root, 'node_modules'), { recursive: true, force: true });
+
+        const result = spawnSync(process.execPath, [CLI], { cwd: root, encoding: 'utf8' });
+
+        expect(result.stderr).toContain('install ts-node, tsx or @swc-node/register');
+        expect(result.status).toBe(1);
+    });
+});


### PR DESCRIPTION
## Problem

In an ESM project, `wz-command` probes each TypeScript loader with `require.resolve('<name>/package.json')`. `@swc-node/register` declares an `exports` map that does not expose `./package.json`, so the probe throws `ERR_PACKAGE_PATH_NOT_EXPORTED` and the loader is treated as missing:

```
Cannot run .../src/cli.ts: install ts-node (or tsx) to execute a TypeScript entry file in an ESM project.
```

Projects that rely on `@swc-node/register` (and have neither `ts-node` nor `tsx`) cannot run any command against `src/cli.ts`.

## Fix

- Probe the package directory along the consumer's resolution paths (`require.resolve.paths(name)` + `fs.existsSync`) instead of going through the `exports` map.
- Error message and README now list all three supported loaders: `ts-node`, `tsx`, `@swc-node/register`.
- Bump to `12.3.1`.

## Tests

New `tests/bin-cli.spec.ts` spawns the bin against a temporary ESM app whose only loader is a stand-in for `@swc-node/register` with the same `exports` shape:
- fails before the fix with the exact error above, passes after (loader registered, entry executed, exit 0)
- with no loader installed, the CLI still fails clearly with exit 1

Also verified against a real consumer (employer-backend `apps/user`): `pnpm --filter user wz-command generate-login-token ...` now runs from `src/cli.ts` without `CLI_PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)